### PR TITLE
Spam filter in sieve after

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Mail:
 
 Control panel:
 
-* RSASHA256 is now used for DNSSEC for for .lv domains.
+* RSASHA256 is now used for DNSSEC for .lv domains.
 * Some documentation/links improvements.
 
 Installer:

--- a/setup/mail-dovecot.sh
+++ b/setup/mail-dovecot.sh
@@ -181,9 +181,9 @@ sed -i "s/#mail_plugins = .*/mail_plugins = \$mail_plugins sieve/" /etc/dovecot/
 # is also where the ManageSieve service stores the user's scripts.
 cat > /etc/dovecot/conf.d/99-local-sieve.conf << EOF;
 plugin {
-  sieve_before = /etc/dovecot/sieve-spam.sieve
-  sieve_before2 = $STORAGE_ROOT/mail/sieve/global_before
-  sieve_after = $STORAGE_ROOT/mail/sieve/global_after
+  sieve_before = $STORAGE_ROOT/mail/sieve/global_before
+  sieve_after = /etc/dovecot/sieve-spam.sieve
+  sieve_after2 = $STORAGE_ROOT/mail/sieve/global_after
   sieve = $STORAGE_ROOT/mail/sieve/%d/%n.sieve
   sieve_dir = $STORAGE_ROOT/mail/sieve/%d/%n
 }


### PR DESCRIPTION
With this change, we move spam mails to the spam folder only after the user sieve scripts have run

This allows sieve scripts of users to still handle spam mails themselves and move them around instead of them being strictly forced into the spam folder. If required, the user scripts can also stop evaluation of further rules in order to not send an identified spam mail to the spam folder at all.

Note that this change potentially affects existing setups. All user-rules are also run for spam mails now. This includes auto responders. If required, users might want to manually exclude spam mails by excluding mails with `X-Spam-Status: Yes`.